### PR TITLE
Added functionality to get previous messages and more

### DIFF
--- a/server/src/controllers/userRoomMapping/index.ts
+++ b/server/src/controllers/userRoomMapping/index.ts
@@ -1,4 +1,5 @@
 import * as mappingOps from '../../sqlz/ops/mappingUserToRoom'
+import * as roomOps from '../../sqlz/ops/rooms'
 import { Request, Response } from 'express'
 
 export function addUserRoomMapping(req: Request, res: Response) {
@@ -10,8 +11,14 @@ export function addUserRoomMapping(req: Request, res: Response) {
   }
 
   try {
-    mappingOps.addUserRoomMapping(username, roomId).then(() => {
-      res.status(200).send({ msg: 'Mapping added successfully.' })
+    roomOps.checkIfRoomExists(roomId).then(roomExists => {
+      if (roomExists) {
+        mappingOps.addUserRoomMapping(username, roomId).then(() => {
+          res.status(200).send({ msg: 'Mapping added successfully.' })
+        })
+      } else {
+        res.status(400).send({ msg: 'Room does not exist.' })
+      }
     })
   } catch (err) {
     res.status(500).send({

--- a/server/src/sqlz/models/messages.ts
+++ b/server/src/sqlz/models/messages.ts
@@ -1,4 +1,4 @@
-import { STRING, TEXT } from 'sequelize'
+import { STRING, TEXT, BIGINT } from 'sequelize'
 import sequelize from './index'
 
 const Messages = sequelize.define(
@@ -16,6 +16,9 @@ const Messages = sequelize.define(
     },
     roomId: {
       type: STRING,
+    },
+    unixTime: {
+      type: BIGINT,
     },
   },
   {

--- a/server/src/sqlz/ops/mappingUserToRoom.ts
+++ b/server/src/sqlz/ops/mappingUserToRoom.ts
@@ -3,8 +3,22 @@ import Users from '../models/users'
 import Rooms from '../models/rooms'
 import mappingUserToRoom from '../models/mappingUserToRoom'
 
+export async function checkUserInRoom(username, roomId) {
+  const user: any = await Users.findOne({ where: { username: username } })
+  if (!user) {
+    return false
+  }
+
+  const userId = user.userId
+
+  const found = await mappingUserToRoom.findOne({ where: { roomId, userId } })
+  return found ? true : false
+}
+
 export async function addUserRoomMapping(username: string, roomId: string) {
   const user: any = await Users.findOne({ where: { username: username } })
+  if (!user) return
+
   const userId = user.userId
 
   const found = await mappingUserToRoom.findOne({ where: { roomId, userId } })
@@ -15,6 +29,10 @@ export async function addUserRoomMapping(username: string, roomId: string) {
 
 export async function getRoomsOfUser(username: string) {
   const user: any = await Users.findOne({ where: { username: username } })
+  if (!user) {
+    return []
+  }
+
   const userId = user.userId
 
   const mappingsOfUser = await mappingUserToRoom.findAll({ where: { userId } })

--- a/server/src/sqlz/ops/messages.ts
+++ b/server/src/sqlz/ops/messages.ts
@@ -1,21 +1,36 @@
 import Users from '../models/users'
 import Messages from '../models/messages'
 import { nanoid } from 'nanoid'
+import { QueryTypes } from 'sequelize'
+import sequelize from '../../sqlz/models'
 
-export async function getMessages(roomId) {
-  const messages = await Messages.findAll({
-    where: { roomId: roomId },
-    limit: 10,
-  })
-  return messages
+export async function getMessages(roomId, messageId) {
+  if (messageId === undefined) {
+    const messages = await sequelize.query(
+      'select * from "Messages" m where "roomId" = ? order by "unixTime" desc limit 25',
+      { replacements: [roomId], type: QueryTypes.SELECT }
+    )
+
+    return messages
+  } else {
+    const messages = await sequelize.query(
+      'select * from "Messages" m2 where m2."unixTime" < \
+      (select "unixTime" from "Messages" m where m."messageId" = ? ) and "roomId" = ? \
+      order by "unixTime" desc limit 25',
+      { replacements: [messageId, roomId], type: QueryTypes.SELECT }
+    )
+
+    return messages
+  }
 }
 
 export async function postMessage(username, content, roomId) {
   const user: any = await Users.findOne({ where: { username: username } })
   const userId = user.userId
   const messageId = nanoid()
+  const unixTime = Date.now()
 
-  await Messages.create({ messageId, content, userId, roomId })
+  await Messages.create({ messageId, content, userId, roomId, unixTime })
 
   return messageId
 }

--- a/server/src/sqlz/ops/rooms.ts
+++ b/server/src/sqlz/ops/rooms.ts
@@ -18,3 +18,9 @@ export async function createRoom(username: string, roomName: string) {
 
   return roomId
 }
+
+export async function checkIfRoomExists(roomId: string) {
+  const room: any = await Rooms.findOne({ where: { roomId: roomId } })
+
+  return room ? true : false
+}


### PR DESCRIPTION
Work done:
- Functionality to get previous messages after some specific message: Can be used by sending the messageId and roomId to the exiting get messages route, also if no messageId is provided - the route will return the latest messages instead. The current number of messages returned is limited to 25 for now and ordered by latest first.
-  Now, the get messages route would not automatically add the user in room (which it earlier did). Instead it will check if the user exists in the room and if the user does not, it will return a 403 error. So, every user must now join the room by the add user to room route.
- Added some other checks so only valid values of userId and roomId will be added in the user-room mapping.